### PR TITLE
feat: add support for Rive files

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "watch": "pkg-utils watch"
   },
   "dependencies": {
+    "@rive-app/react-canvas": "^4.13.6",
     "@sanity/incompatible-plugin": "^1.0.4",
     "@sanity/ui": "^1.0.2",
     "video.js": "^7.11.4"

--- a/src/components/RiveAnimationPreview.tsx
+++ b/src/components/RiveAnimationPreview.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { useRive } from '@rive-app/react-canvas';
+import { useState } from 'react';
+
+interface RiveAnimationPreviewProps {
+  riveUrl: string;
+  previewImg: string;
+  aspectRatio: number;
+}
+
+export default function RiveAnimationPreview({
+  riveUrl,
+  previewImg,
+  aspectRatio,
+}: RiveAnimationPreviewProps) {
+  const [loaded, setLoaded] = useState(false);
+  const { RiveComponent } = useRive({
+    src: riveUrl,
+    autoplay: true,
+    onLoad: () => setLoaded(true),
+  });
+  return (
+    <div style={{ width: '100%', aspectRatio: `1/${aspectRatio}` }}>
+      {!loaded && (
+        <img src={previewImg} style={{ width: '100%', objectFit: 'cover' }} />
+      )}
+      {
+        <RiveComponent
+          style={{
+            width: '100%',
+            objectFit: 'cover',
+            display: loaded ? 'block' : 'none',
+          }}
+        />
+      }
+    </div>
+  );
+}

--- a/src/schema/bynder.asset.ts
+++ b/src/schema/bynder.asset.ts
@@ -33,6 +33,8 @@ export interface BynderAssetValue {
   previewUrl?: string;
   previewImg?: string;
   datUrl?: string;
+  originalUrl?: string;
+  thumbnailUrl?: string;
   description?: string;
   aspectRatio?: number;
   videoUrl?: string;
@@ -82,6 +84,14 @@ export const bynderAssetSchema = defineType({
     {
       type: 'string',
       name: 'videoUrl',
+    },
+    {
+      type: 'string',
+      name: 'originalUrl',
+    },
+    {
+      type: 'string',
+      name: 'thumbnailUrl',
     },
   ],
   components: {


### PR DESCRIPTION
At Brex, we feel the need for a better support for picking and previewing .riv (Rive animation) files in Bynder through this Sanity plugin. 

What this PR does: 

- exposes both the original file and its thumbnail URLs from Bynder in the schema;
- calculates the animation aspect ratio just as it does for videos already; 
- allows for animation preview on Sanity after the file is picked (this requires the `@rive-app/react-canvas` package, which was added as we feel this really improves the user experience).

Please, let me know if any change is needed. 

