### PR TITLE
feat: pass the asset dimensions down to the sanity object

### DIFF
--- a/src/components/BynderInput.tsx
+++ b/src/components/BynderInput.tsx
@@ -89,6 +89,10 @@ export function BynderInput(props: BynderInputProps) {
         videoUrl: getVideoUrl(asset),
         description: asset.description,
         aspectRatio,
+        width: webImage.width,
+        height: webImage.height,
+        // If Bynder supported mimeType in the schema, we could set it here
+        //mimeType: webImage.mimeType,
       };
 
       if (asset.type === 'VIDEO') {

--- a/src/schema/bynder.asset.ts
+++ b/src/schema/bynder.asset.ts
@@ -93,6 +93,14 @@ export const bynderAssetSchema = defineType({
       name: 'aspectRatio',
     },
     {
+      type: 'number',
+      name: 'width',
+    },
+    {
+      type: 'number',
+      name: 'height',
+    },
+    {
       type: 'string',
       name: 'videoUrl',
     },


### PR DESCRIPTION
This allows for `width` and `height` to be available on the object passed from Bynder to Sanity. 

It uses the same values as what's used to determine and pass the aspect ratio